### PR TITLE
Show minimap by default

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,9 +57,9 @@ Minimap Scroller uses an optimized render of the webpage, without images or heav
 
 The rendering is automatically updated when important elements change on the web page.
 
-3. **Minimized**
+3. **Minimap always visible**
 
-Thanks to the strip, open the mini map only when you need it.
+The minimap now appears by default so you can immediately navigate the page.
 
 
 

--- a/src/map_proc.js
+++ b/src/map_proc.js
@@ -16,9 +16,11 @@ function init() {
 		document.body.appendChild(languette);
 
 		// Add minimap container to the page
-		const minimapContainer = document.createElement('div');
-		minimapContainer.id = 'dom-minimap-container';
-		document.body.appendChild(minimapContainer);
+                const minimapContainer = document.createElement('div');
+                minimapContainer.id = 'dom-minimap-container';
+                document.body.appendChild(minimapContainer);
+                // Keep minimap visible by default
+                minimapContainer.style.right = '0px';
 		
 		// Scrollbox canvas
 		const canvass = document.createElement('canvas');
@@ -159,24 +161,14 @@ function init() {
 			isDragging = false;
 		};
 
-		// Add event listeners for canvas
-		languette.addEventListener('mouseover', e => {
-			minimapContainer.style.right = '0px';
-		});
-		canvass.addEventListener('mouseout', e => {
-			minimapContainer.style.right = '-101px';
-		});
-		canvass.addEventListener('mousedown', handleMouseDown);
-		canvass.addEventListener('mousemove', handleMouseMove);
-		canvass.addEventListener('mouseup', handleMouseUp);
-		canvass.addEventListener('mouseleave', handleMouseUp);
-		document.getElementById('languette').addEventListener('mouseenter', function (e) {
-			scheduleRender(true);
-		});
-		document.addEventListener("mouseleave", function(event) {
-			if(event.clientY <= 0 || event.clientX <= 0 || (event.clientX >= window.innerWidth || event.clientY >= window.innerHeight))
-				minimapContainer.style.right = '-101px';
-		});
+                // Keep minimap visible at all times
+                canvass.addEventListener('mousedown', handleMouseDown);
+                canvass.addEventListener('mousemove', handleMouseMove);
+                canvass.addEventListener('mouseup', handleMouseUp);
+                canvass.addEventListener('mouseleave', handleMouseUp);
+                document.getElementById('languette').addEventListener('mouseenter', function (e) {
+                        scheduleRender(true);
+                });
 
 
 		// Schedule render based on DOM mutation

--- a/src/style.css
+++ b/src/style.css
@@ -2,7 +2,7 @@
 	pointer-events: none;
   position: fixed;
   top: 0px;
-  right: -101px;
+  right: 0px;
   width: 100px;
   height: calc(100vh - 0px);
   overflow: hidden;


### PR DESCRIPTION
## Summary
- set minimap container to be visible by default
- remove hide/show code so map stays open
- document that the minimap is always visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68781ef2ea648327b69950a2e20257e4