### PR TITLE
Enable minimap by default

### DIFF
--- a/src/map_proc.js
+++ b/src/map_proc.js
@@ -18,7 +18,8 @@ function init() {
 		// Add minimap container to the page
 		const minimapContainer = document.createElement('div');
 		minimapContainer.id = 'dom-minimap-container';
-		document.body.appendChild(minimapContainer);
+                document.body.appendChild(minimapContainer);
+                minimapContainer.style.right = '0px';
 		
 		// Scrollbox canvas
 		const canvass = document.createElement('canvas');
@@ -159,24 +160,11 @@ function init() {
 			isDragging = false;
 		};
 
-		// Add event listeners for canvas
-		languette.addEventListener('mouseover', e => {
-			minimapContainer.style.right = '0px';
-		});
-		canvass.addEventListener('mouseout', e => {
-			minimapContainer.style.right = '-101px';
-		});
-		canvass.addEventListener('mousedown', handleMouseDown);
-		canvass.addEventListener('mousemove', handleMouseMove);
-		canvass.addEventListener('mouseup', handleMouseUp);
-		canvass.addEventListener('mouseleave', handleMouseUp);
-		document.getElementById('languette').addEventListener('mouseenter', function (e) {
-			scheduleRender(true);
-		});
-		document.addEventListener("mouseleave", function(event) {
-			if(event.clientY <= 0 || event.clientX <= 0 || (event.clientX >= window.innerWidth || event.clientY >= window.innerHeight))
-				minimapContainer.style.right = '-101px';
-		});
+                // Add event listeners for canvas
+                canvass.addEventListener('mousedown', handleMouseDown);
+                canvass.addEventListener('mousemove', handleMouseMove);
+                canvass.addEventListener('mouseup', handleMouseUp);
+                canvass.addEventListener('mouseleave', handleMouseUp);
 
 
 		// Schedule render based on DOM mutation
@@ -229,10 +217,12 @@ function init() {
 		});
 
 		// Adjust canvas size on window resize
-		window.addEventListener('resize', () => {
-			scheduleRender();
-		});
-	});
+                window.addEventListener('resize', () => {
+                        scheduleRender();
+                });
+
+                scheduleRender(true);
+        });
 }
 
 function desinit() {

--- a/src/style.css
+++ b/src/style.css
@@ -2,7 +2,7 @@
 	pointer-events: none;
   position: fixed;
   top: 0px;
-  right: -101px;
+  right: 0px;
   width: 100px;
   height: calc(100vh - 0px);
   overflow: hidden;
@@ -26,16 +26,7 @@
 	writing-mode: vertical-rl;
   text-orientation: mixed;
 	
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  align-content: center;
-  justify-content: center;
-  align-items: center;
-  font-size: 13px;
-  color: #ff9e9e;
-	
-	cursor: pointer;
+  display: none;
 }
 
 #dom-minimap, #dom-scrollbox {


### PR DESCRIPTION
## Summary
- show the minimap container by default
- hide the "Minimap" toggle button
- render the minimap as soon as the page loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68781ef2ea648327b69950a2e20257e4