### PR TITLE
Enable minimap by default

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,9 +57,9 @@ Minimap Scroller uses an optimized render of the webpage, without images or heav
 
 The rendering is automatically updated when important elements change on the web page.
 
-3. **Minimized**
+3. **Always visible**
 
-Thanks to the strip, open the mini map only when you need it.
+The mini map is displayed automatically on every page without any extra action.
 
 
 

--- a/src/map_proc.js
+++ b/src/map_proc.js
@@ -9,16 +9,11 @@ function init() {
 		let lastRenderTime = 0;
 		let renderUID = 0;
 		
-		// Add languette
-		const languette = document.createElement('div');
-		languette.id = 'languette';
-		languette.innerText = 'Minimap';
-		document.body.appendChild(languette);
-
-		// Add minimap container to the page
-		const minimapContainer = document.createElement('div');
-		minimapContainer.id = 'dom-minimap-container';
-		document.body.appendChild(minimapContainer);
+                // Add minimap container to the page
+                const minimapContainer = document.createElement('div');
+                minimapContainer.id = 'dom-minimap-container';
+                document.body.appendChild(minimapContainer);
+                minimapContainer.style.right = '0px';
 		
 		// Scrollbox canvas
 		const canvass = document.createElement('canvas');
@@ -159,24 +154,11 @@ function init() {
 			isDragging = false;
 		};
 
-		// Add event listeners for canvas
-		languette.addEventListener('mouseover', e => {
-			minimapContainer.style.right = '0px';
-		});
-		canvass.addEventListener('mouseout', e => {
-			minimapContainer.style.right = '-101px';
-		});
-		canvass.addEventListener('mousedown', handleMouseDown);
-		canvass.addEventListener('mousemove', handleMouseMove);
-		canvass.addEventListener('mouseup', handleMouseUp);
-		canvass.addEventListener('mouseleave', handleMouseUp);
-		document.getElementById('languette').addEventListener('mouseenter', function (e) {
-			scheduleRender(true);
-		});
-		document.addEventListener("mouseleave", function(event) {
-			if(event.clientY <= 0 || event.clientX <= 0 || (event.clientX >= window.innerWidth || event.clientY >= window.innerHeight))
-				minimapContainer.style.right = '-101px';
-		});
+                // Add event listeners for canvas
+                canvass.addEventListener('mousedown', handleMouseDown);
+                canvass.addEventListener('mousemove', handleMouseMove);
+                canvass.addEventListener('mouseup', handleMouseUp);
+                canvass.addEventListener('mouseleave', handleMouseUp);
 
 
 		// Schedule render based on DOM mutation
@@ -229,16 +211,18 @@ function init() {
 		});
 
 		// Adjust canvas size on window resize
-		window.addEventListener('resize', () => {
-			scheduleRender();
-		});
-	});
+                window.addEventListener('resize', () => {
+                        scheduleRender();
+                });
+
+                // Initial render
+                scheduleRender(true);
+        });
 }
 
 function desinit() {
-	if (document.body.contains(document.getElementById('dom-minimap-container'))) {
-		document.getElementById('dom-minimap-container').remove();
-		document.getElementById('languette').remove();
-		observer.disconnect();
-	}
+        if (document.body.contains(document.getElementById('dom-minimap-container'))) {
+                document.getElementById('dom-minimap-container').remove();
+                observer.disconnect();
+        }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -2,7 +2,7 @@
 	pointer-events: none;
   position: fixed;
   top: 0px;
-  right: -101px;
+  right: 0px;
   width: 100px;
   height: calc(100vh - 0px);
   overflow: hidden;
@@ -10,34 +10,8 @@
   z-index: 15000;
   background-color: transparent;
 	outline: #8B0000 1px solid;
-	transition: right 0.125s ease;
 	cursor: grab;
 }
-#languette {
-	background-color: #8B0000;
-  position: fixed;
-  right: 0px;
-  top: calc(50% - 15%);
-  height: 15%;
-  width: 20px;
-  border-radius: 7px 0px 0px 7px;
-  z-index: 14000;
-	
-	writing-mode: vertical-rl;
-  text-orientation: mixed;
-	
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  align-content: center;
-  justify-content: center;
-  align-items: center;
-  font-size: 13px;
-  color: #ff9e9e;
-	
-	cursor: pointer;
-}
-
 #dom-minimap, #dom-scrollbox {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- make minimap container visible on load
- remove hover strip and related styles
- update README feature description

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68781ef2ea648327b69950a2e20257e4